### PR TITLE
Compatibility with python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,7 @@ setup(
         'License :: Public Domain',
         'Operating System :: OS Independent',
         'Topic :: Software Development :: Libraries :: Python Modules',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
     ],
 )

--- a/src/basin.py
+++ b/src/basin.py
@@ -13,14 +13,13 @@ def encode(alphabet, n):
     base-N representation of `n`, where N is the length of `alphabet`.
     
     """
-    
     if not (isinstance(n, int) or isinstance(n, long)):
         raise TypeError('value to encode must be an int or long')
     r = []
     base  = len(alphabet)
     while n >= base:
         r.append(alphabet[n % base])
-        n = n / base
+        n = n // base
     r.append(str(alphabet[n % base]))
     r.reverse()
     return ''.join(r)
@@ -31,6 +30,10 @@ def decode(alphabet, string):
     Determine the integer value encoded by `string` with alphabet `alphabet`.
     
     """
+    try:
+        basestring
+    except NameError:
+        basestring = str
     if not isinstance(string, basestring):
         raise TypeError('value to decode must be a string')
     r = 0

--- a/src/tests.py
+++ b/src/tests.py
@@ -1,0 +1,16 @@
+import unittest
+
+import basin
+
+
+class Test(unittest.TestCase):
+
+    def test_encode(self):
+        self.assertEqual("a", basin.encode("abc", 0))
+        self.assertEqual("ba", basin.encode("abc", 3))
+
+    def test_decode(self):
+        self.assertEqual(0, basin.decode("abc", "a"))
+        self.assertEqual(3, basin.decode("abc", "ba"))
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py34
+
+[testenv]
+commands = nosetests
+deps =
+    nose
+


### PR DESCRIPTION
The patch provides a compatibility for python 2.7 and 3 for the library.
It's checked by tests runned by tox.

The version used for checking python3 is v.3.4 but you can change it (to 3.5 for example) without problems.

Do you still maintain this library or do you use another one?
